### PR TITLE
fix: dimensionless comment

### DIFF
--- a/LA4DS_ch02.ipynb
+++ b/LA4DS_ch02.ipynb
@@ -67,7 +67,7 @@
     "# a vector as a Python list datatype\n",
     "asList = [1,2,3]\n",
     "\n",
-    "# same numbers, but as a dimensionless numpy array\n",
+    "# same numbers, but as an orientationless numpy array\n",
     "asArray = np.array([1,2,3])\n",
     "\n",
     "# again same numbers, but now endowed with orientations\n",

--- a/pyFiles/LA4DS_ch02.py
+++ b/pyFiles/LA4DS_ch02.py
@@ -11,7 +11,7 @@ plt.rcParams.update({'font.size':14}) # set global font size
 # a vector as a Python list datatype
 asList = [1,2,3]
 
-# same numbers, but as a dimensionless numpy array
+# same numbers, but as an orientationless numpy array
 asArray = np.array([1,2,3])
 
 # again same numbers, but now endowed with orientations


### PR DESCRIPTION
I think these comments are supposed to say orientationless instead of dimensionless. In the book it says

> `asArray = np.array([1,2,3]) # 1D array`
> ...
> The variable `asArray` is an orientationless array
> ...
> The output shows that the 1D array `asArray` is of size (3), whereas the orientation-endowed vectors are 2D arrays and are stored as size (1,3) or (3,1) depending on the orientation

signaling it has one dimension. The comment that follows makes sense only if the line of code in question has no orientations.